### PR TITLE
Panic recoverとBasic認証のMiddlewareの実装

### DIFF
--- a/handler/do-panic.go
+++ b/handler/do-panic.go
@@ -1,0 +1,19 @@
+package handler
+
+import (
+	"net/http"
+)
+
+// A DoPanicHandler implements do panic endpoint.
+type DoPanicHandler struct{}
+
+// NewDoPanicHandler returns DoPanicHandler based http.Handler.
+func NewDoPanicHandler() *DoPanicHandler {
+	return &DoPanicHandler{}
+}
+
+// ServeHTTP implements http.Handler interface.
+func (h *DoPanicHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// ivoke panic
+	panic("do-panic")
+}

--- a/handler/middleware/auth.go
+++ b/handler/middleware/auth.go
@@ -2,15 +2,10 @@ package middleware
 
 import (
 	"net/http"
-	"os"
 )
 
-func BasicAuthMiddleware(h http.Handler) http.Handler {
+func BasicAuthMiddleware(h http.Handler, username, password string) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		// usernameとpasswordは環境変数から取得
-		username := os.Getenv("BASIC_AUTH_USER_ID")
-		password := os.Getenv("BASIC_AUTH_PASSWORD")
-
 		// Basic認証のユーザー名とパスワードを取得
 		user, pass, ok := r.BasicAuth()
 

--- a/handler/middleware/auth.go
+++ b/handler/middleware/auth.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"net/http"
+	"os"
+)
+
+func BasicAuthMiddleware(h http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		// usernameとpasswordは環境変数から取得
+		username := os.Getenv("BASIC_AUTH_USER_ID")
+		password := os.Getenv("BASIC_AUTH_PASSWORD")
+
+		// Basic認証のユーザー名とパスワードを取得
+		user, pass, ok := r.BasicAuth()
+
+		// Basic認証情報がない(または空で送られくる)、またはユーザー名とパスワードが一致しない場合は401 Unauthorizedを返す
+		if !ok || len(user) == 0 || len(pass) == 0 || user != username || pass != password {
+			// WWW-Authenticate ヘッダーを設定
+			w.Header().Set("WWW-Authenticate", `Basic realm="restricted"`)
+			// 401 Unauthorized ステータスコードを設定
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		h.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}

--- a/handler/middleware/auth.go
+++ b/handler/middleware/auth.go
@@ -10,7 +10,7 @@ func BasicAuthMiddleware(h http.Handler, username, password string) http.Handler
 		user, pass, ok := r.BasicAuth()
 
 		// Basic認証情報がない(または空で送られくる)、またはユーザー名とパスワードが一致しない場合は401 Unauthorizedを返す
-		if !ok || len(user) == 0 || len(pass) == 0 || user != username || pass != password {
+		if !ok || user == "" || pass == "" || user != username || pass != password {
 			// WWW-Authenticate ヘッダーを設定
 			w.Header().Set("WWW-Authenticate", `Basic realm="restricted"`)
 			// 401 Unauthorized ステータスコードを設定

--- a/handler/middleware/recovery.go
+++ b/handler/middleware/recovery.go
@@ -1,0 +1,17 @@
+package middleware
+
+import "net/http"
+
+func Recovery(h http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		// severHTTP内でpanicが発生した場合でもdeferは実行される
+		// recoverはdeferの中でのみ使用可能
+		defer func() {
+			if err := recover(); err != nil {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}()
+		h.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}

--- a/handler/middleware/recovery.go
+++ b/handler/middleware/recovery.go
@@ -1,6 +1,9 @@
 package middleware
 
-import "net/http"
+import (
+	"log"
+	"net/http"
+)
 
 func Recovery(h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
@@ -8,6 +11,8 @@ func Recovery(h http.Handler) http.Handler {
 		// recoverはdeferの中でのみ使用可能
 		defer func() {
 			if err := recover(); err != nil {
+				// panic理由とURLをログに出力
+				log.Printf("panic: %v, URL: %s", err, r.URL.String())
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			}
 		}()

--- a/handler/router/router.go
+++ b/handler/router/router.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/TechBowl-japan/go-stations/handler"
+	"github.com/TechBowl-japan/go-stations/handler/middleware"
 	"github.com/TechBowl-japan/go-stations/service"
 )
 
@@ -12,7 +13,8 @@ func NewRouter(todoDB *sql.DB) *http.ServeMux {
 	// register routes
 	mux := http.NewServeMux()
 	// /healthzの時にHealthzHandlerを呼び出す
-	mux.Handle("/healthz", handler.NewHealthzHandler())
+	// do-panicの時にmiddlewareのRecoveryを通してDoPanicHandlerを呼び出す
+	mux.Handle("/do-panic", middleware.Recovery(handler.NewDoPanicHandler()))
 
 	//todoDBを使ってserviceを作成
 	todoService := service.NewTODOService(todoDB)

--- a/handler/router/router.go
+++ b/handler/router/router.go
@@ -9,18 +9,18 @@ import (
 	"github.com/TechBowl-japan/go-stations/service"
 )
 
-func NewRouter(todoDB *sql.DB) *http.ServeMux {
+func NewRouter(todoDB *sql.DB, username, password string) *http.ServeMux {
 	// register routes
 	mux := http.NewServeMux()
 	// /healthzの時にHealthzHandlerを呼び出す
-	mux.Handle("/healthz", middleware.BasicAuthMiddleware(handler.NewHealthzHandler()))
+	mux.Handle("/healthz", handler.NewHealthzHandler())
 
 	// do-panicの時にmiddlewareのRecoveryを通してDoPanicHandlerを呼び出す
 	mux.Handle("/do-panic", middleware.Recovery(handler.NewDoPanicHandler()))
 
 	//todoDBを使ってserviceを作成
 	todoService := service.NewTODOService(todoDB)
-	mux.Handle("/todos", handler.NewTODOHandler(todoService))
+	mux.Handle("/todos", middleware.BasicAuthMiddleware(handler.NewTODOHandler(todoService), username, password))
 
 	return mux
 }

--- a/handler/router/router.go
+++ b/handler/router/router.go
@@ -13,6 +13,8 @@ func NewRouter(todoDB *sql.DB) *http.ServeMux {
 	// register routes
 	mux := http.NewServeMux()
 	// /healthzの時にHealthzHandlerを呼び出す
+	mux.Handle("/healthz", middleware.BasicAuthMiddleware(handler.NewHealthzHandler()))
+
 	// do-panicの時にmiddlewareのRecoveryを通してDoPanicHandlerを呼び出す
 	mux.Handle("/do-panic", middleware.Recovery(handler.NewDoPanicHandler()))
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,13 @@ import (
 	"github.com/TechBowl-japan/go-stations/handler/router"
 )
 
+// 環境変数から取得した値を使ってサーバーを起動する
+var (
+	// Basic Auth用のユーザー名とパスワードを環境変数から取得
+	username = os.Getenv("BASIC_AUTH_USER_ID")
+	password = os.Getenv("BASIC_AUTH_PASSWORD")
+)
+
 func main() {
 	err := realMain()
 	if err != nil {
@@ -48,8 +55,8 @@ func realMain() error {
 	}
 	defer todoDB.Close()
 
-	// NOTE: 新しいエンドポイントの登録はrouter.NewRouterの内部で行うようにする
-	mux := router.NewRouter(todoDB)
+	// NOTE: 新しいエンドポイントの登録はrouter.NewRouterの内部で行うようにする.
+	mux := router.NewRouter(todoDB, username, password)
 
 	// TODO: サーバーをlistenする
 	http.ListenAndServe(port, mux)


### PR DESCRIPTION
## 基礎編の以下3つのstationの実装
- [PanicをRecoverするMiddlewareを実装してみよう](https://techtrain.dev/mypage/railway/30/station/710)
- [Basic認証を導入してみよう](https://techtrain.dev/mypage/railway/30/station/713)
- [Basic認証の検証作業をしてみよう](https://techtrain.dev/mypage/railway/30/station/714)

## 動作確認
### PanicをRecoverするMiddlewareを実装
`/do-panic`にアクセスした後に、`/todos`にアクセスできることを確認。

### Basic認証するMiddlewareを実装
環境変数は以下の値に設定
```
export BASIC_AUTH_USER_ID=shinnosuke
export BASIC_AUTH_PASSWORD=P@ssw0rd
```
以下4つの場合を検証
- Basic認証を行わない場合(1枚目)
- Basic認証を行うが入力情報が空文字の場合(2枚目)
- Basic認証を行うが入力情報が環境変数に設定した情報と異なる場合(3枚目)
- Bascie認証を行い、入力情報が環境変数に設定した情報に一致する場合(4枚目)
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/fef22dcd-b34e-4202-8976-3f11268ce8f2">  
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/63be5ddf-8f2f-47ea-bb44-ec87e134138e">  
<img width="1016" alt="image" src="https://github.com/user-attachments/assets/2949b597-89ae-4197-89db-01a8602714a7">  
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/09a476c0-9531-42f8-abf7-fd2b21942673">

