### PR TITLE
Access logを出力するMiddlewareの実装

### DIFF
--- a/common/os.go
+++ b/common/os.go
@@ -13,11 +13,11 @@ func GetOsName(req *http.Request) string {
 	// リクエストヘッダーからUser-Agentを取得
 	userAgent := req.Header.Get("User-Agent")
 	// useragentを使ってOSを取得
-	OsName := useragent.Parse(userAgent).OS
-	return OsName
+	osName := useragent.Parse(userAgent).OS
+	return osName
 }
 
 // 取得したOsNameをcontextに格納する
-func SetOsName(ctx context.Context, OsName string) context.Context {
-	return context.WithValue(ctx, OsNameKeyType{}, OsName)
+func SetOsName(ctx context.Context, osName string) context.Context {
+	return context.WithValue(ctx, OsNameKeyType{}, osName)
 }

--- a/common/os.go
+++ b/common/os.go
@@ -1,0 +1,23 @@
+package common
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/mileusna/useragent"
+)
+
+type OsNameKeyType struct{}
+
+func GetOsName(req *http.Request) string {
+	// リクエストヘッダーからUser-Agentを取得
+	userAgent := req.Header.Get("User-Agent")
+	// useragentを使ってOSを取得
+	OsName := useragent.Parse(userAgent).OS
+	return OsName
+}
+
+// 取得したOsNameをcontextに格納する
+func SetOsName(ctx context.Context, OsName string) context.Context {
+	return context.WithValue(ctx, OsNameKeyType{}, OsName)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/mattn/go-sqlite3 v1.14.7
+	github.com/mileusna/useragent v1.3.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfE
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEghA=
 github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mileusna/useragent v1.3.4 h1:MiuRRuvGjEie1+yZHO88UBYg8YBC/ddF6T7F56i3PCk=
+github.com/mileusna/useragent v1.3.4/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=

--- a/handler/middleware/access-logging.go
+++ b/handler/middleware/access-logging.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/TechBowl-japan/go-stations/common"
+)
+
+// ログに出力する構造体を定義
+type AccessLogging struct {
+	Timestamp time.Time
+	Latency   int64
+	Path      string
+	OS        string
+}
+
+// アクセス日時、リクエストパス、処理時間を出力するミドルウェア
+func AccessLoggingMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// OsNameを取得
+		OsName := common.GetOsName(r)
+		// contextに格納
+		ctx := common.SetOsName(r.Context(), OsName)
+		r = r.WithContext(ctx)
+
+		// handlerのアクセス時刻を取得
+		start := time.Now()
+		// ハンドラに渡す
+		h.ServeHTTP(w, r)
+		// handlerの処理時間を取得
+		duration := time.Since(start)
+		// AccessLoggingにアクセス日時、処理時間、リクエストパスを格納
+		al := AccessLogging{
+			Timestamp: start,
+			Latency:   duration.Milliseconds(),
+			Path:      r.URL.Path,
+			OS:        OsName,
+		}
+
+		fmt.Println(al)
+	})
+}

--- a/handler/middleware/access-logging.go
+++ b/handler/middleware/access-logging.go
@@ -20,9 +20,9 @@ type AccessLogging struct {
 func AccessLoggingMiddleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// OsNameを取得
-		OsName := common.GetOsName(r)
+		osName := common.GetOsName(r)
 		// contextに格納
-		ctx := common.SetOsName(r.Context(), OsName)
+		ctx := common.SetOsName(r.Context(), osName)
 		r = r.WithContext(ctx)
 
 		// handlerのアクセス時刻を取得
@@ -36,7 +36,7 @@ func AccessLoggingMiddleware(h http.Handler) http.Handler {
 			Timestamp: start,
 			Latency:   duration.Milliseconds(),
 			Path:      r.URL.Path,
-			OS:        OsName,
+			OS:        osName,
 		}
 
 		fmt.Println(al)

--- a/handler/middleware/access-logging.go
+++ b/handler/middleware/access-logging.go
@@ -39,6 +39,6 @@ func AccessLoggingMiddleware(h http.Handler) http.Handler {
 			OS:        osName,
 		}
 
-		fmt.Println(al)
+		fmt.Printf("%+v\n", al)
 	})
 }

--- a/handler/router/router.go
+++ b/handler/router/router.go
@@ -20,7 +20,7 @@ func NewRouter(todoDB *sql.DB, username, password string) *http.ServeMux {
 
 	//todoDBを使ってserviceを作成
 	todoService := service.NewTODOService(todoDB)
-	mux.Handle("/todos", middleware.BasicAuthMiddleware(handler.NewTODOHandler(todoService), username, password))
+	mux.Handle("/todos", middleware.BasicAuthMiddleware(middleware.AccessLoggingMiddleware(handler.NewTODOHandler(todoService)), username, password))
 
 	return mux
 }


### PR DESCRIPTION
## 基礎編の以下2つのstationの実装
- [Contextにアクセス元のdeviceのOS名を格納するMiddlewareを実装しよう](https://techtrain.dev/mypage/railway/30/station/711)
- [Access log を出力するMiddleware を実装しよう](https://techtrain.dev/mypage/railway/30/station/712)

## 実装内容
以下を出力するmiddlewareを実装
- アクセス日時
- handlerの処理時間
- http.Request の URL
- OS名

## 動作確認
httpリクエストheaderのUser-Agentに以下の様に設定した
1. `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8`
2. `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36`
3. `Mozilla/5.0 (Android 4.3; Mobile; rv:54.0) Gecko/54.0 Firefox/54.0`

**結果**
1. `{2024-08-13 20:58:17.171768 +0900 JST m=+106.361940043 1 /todos macOS}`
2. `{2024-08-13 21:11:46.764319 +0900 JST m=+17.667040459 1 /todos Windows}`
3. `{2024-08-13 21:12:16.87272 +0900 JST m=+47.775150542 0 /todos Android}`

この結果よりstation3の要件を満たすmiddlewareの実装ができた。