### PR TITLE
Graceful Shutdownの実装

### DIFF
--- a/handler/healthz.go
+++ b/handler/healthz.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/TechBowl-japan/go-stations/model"
 )
@@ -17,7 +18,8 @@ func NewHealthzHandler() *HealthzHandler {
 
 // ServeHTTP implements http.Handler interface.
 func (h *HealthzHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-
+	// 5秒後にレスポンスを返す
+	time.Sleep(10 * time.Second)
 	response := &model.HealthzResponse{
 		Message: "OK",
 	}


### PR DESCRIPTION
## 基礎編のstation6の実装
- [HTTPサーバーを安全に終了させよう](https://techtrain.dev/mypage/railway/30/station/715)

## 動作確認
下記のようにサーバーを起動させた後に、ctrlCでmain.goの実行をキャンセルした際にサーバーを起動、シャットダウンをするrealMain関数からエラーが返らず、正常にサーバーがシャットダウンしていることを確認した。
```
$go run main.go 
{Timestamp:2024-08-16 13:27:22.61833 +0900 JST m=+10.106682460 Latency:1 Path:/todos OS:}
^C%                                                   
```