### PR TITLE
WaitGroupからerrgroupを使うように修正

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/mattn/go-sqlite3 v1.14.7
 	github.com/mileusna/useragent v1.3.4 // indirect
+	golang.org/x/sync v0.8.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,5 @@ github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEg
 github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mileusna/useragent v1.3.4 h1:MiuRRuvGjEie1+yZHO88UBYg8YBC/ddF6T7F56i3PCk=
 github.com/mileusna/useragent v1.3.4/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=


### PR DESCRIPTION
## 目的
下記のgracefull shutdownの実装PRでコメントいただいた点を修正するため。
https://github.com/ShinnosukeSuzuki/go-stations/pull/4#discussion_r1719776704

## 動作検証
1. postmanでレスポンスを返すのに10秒かかる`/healthz`に対してリクエスト
2. 1の後すぐにサーバーを実行しているコードで^Cを行う
3. 1つ目とは別のpostmanを使って、`/healthz`に対してリクエストした。
上記の結果1つ目のリクエストに対してはレスポンスを返し、2つ目のリクエストは受け付けずにサーバーがシャットダウンしたことを確認した。
